### PR TITLE
fix: fixed php 8.2 deprecation notice of variable usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-04-05
+### Fixed
+-  Fix php 8.2 deprecation notice: using ${var}
+
 ## [0.2.1] - 2022-06-09
 ### Fixed
 - Remove an existing remote artifact to force a re-download, because the wget -c (continue) option doesn't handle 

--- a/recipe/artifact_s3.php
+++ b/recipe/artifact_s3.php
@@ -54,9 +54,9 @@ task('artifact:s3:deploy', function () {
     $key = get('aws-s3-key');
     $filename = \basename($key);
 
-    run("mkdir -p ${uploadDir}");
+    run("mkdir -p {$uploadDir}");
     info("Downloading artifact from S3, this might take a while...");
-    run("rm -f ${uploadDir}/{$filename} && wget -q -O {$uploadDir}/{$filename} \"{$signedUrl}\"");
+    run("rm -f {$uploadDir}/{$filename} && wget -q -O {$uploadDir}/{$filename} \"{$signedUrl}\"");
 });
 
 task('artifact:deploy', [


### PR DESCRIPTION
Ho @gsomoza,

This PR fixes an error "Deprecation Notice: Using ${var}" when using Deployer with PHP 8.2

Thank you